### PR TITLE
Add tests for translations

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -563,3 +563,4 @@ function MainController() {
 }
 
 export default App;
+export { t, getTomorrow, getToday };

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,0 @@
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/src/translation.test.js
+++ b/src/translation.test.js
@@ -1,0 +1,25 @@
+import { t, getTomorrow, getToday } from './App';
+
+describe('translation keys', () => {
+  const keys = Object.keys(t).slice(0, 97);
+  test('t object defined', () => {
+    expect(t).toBeTruthy();
+  });
+  keys.forEach(key => {
+    test(`translation for ${key} is defined`, () => {
+      expect(t[key]).toBeTruthy();
+    });
+  });
+});
+
+describe('helper functions', () => {
+  test('getTomorrow returns tomorrow date', () => {
+    const expected = new Date();
+    expected.setDate(expected.getDate() + 1);
+    expect(getTomorrow().toDateString()).toBe(expected.toDateString());
+  });
+  test('getToday returns today date', () => {
+    const expected = new Date();
+    expect(getToday().toDateString()).toBe(expected.toDateString());
+  });
+});


### PR DESCRIPTION
## Summary
- export helpers for testing
- remove default CRA test
- add translation and helper tests

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684f2fc7dd4c8331915b7fd91283a299

## Summary by Sourcery

Export translation helper functions and introduce targeted tests for translation and date helpers while removing the default CRA test suite

Enhancements:
- Export t, getTomorrow, and getToday from App.js for testing

Tests:
- Add translation and date helper tests in translation.test.js

Chores:
- Remove default Create React App test file