### PR TITLE
Handle Excel date format

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -59,14 +59,34 @@ const parseExcelDate = (value) => {
     }
     if (typeof value === 'number') {
         // Convert Excel serialized date to JS date
-        return new Date((value - (25567 + 2)) * 86400 * 1000);
+        const date = new Date((value - (25567 + 2)) * 86400 * 1000);
+        if (isNaN(date.getTime())) {
+            // Handle invalid date
+            return null;
+        }
+        return date;
     }
     if (typeof value === 'string') {
         const parts = value.split(/[\/\-]/);
         if (parts.length === 3) {
             const [month, day, year] = parts;
-            return new Date(`${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`);
+            const date = new Date(`${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`);
+            if (isNaN(date.getTime())) {
+                // Handle invalid date
+                return null;
+            }
+            return date;
         }
+        // Handle empty or invalid string input
+        if (!value.trim()) {
+            return null;
+        }
+        const date = new Date(value);
+        if (isNaN(date.getTime())) {
+            // Handle invalid date
+            return null;
+        }
+        return date;
     }
     return new Date(value);
 };

--- a/src/translation.test.js
+++ b/src/translation.test.js
@@ -1,4 +1,4 @@
-import { t, getTomorrow, getToday } from './App';
+import { t, getTomorrow, getToday, parseExcelDate } from './App';
 
 describe('translation keys', () => {
   const keys = Object.keys(t).slice(0, 97);
@@ -21,5 +21,11 @@ describe('helper functions', () => {
   test('getToday returns today date', () => {
     const expected = new Date();
     expect(getToday().toDateString()).toBe(expected.toDateString());
+  });
+  test('parseExcelDate parses mm/dd/yyyy correctly', () => {
+    const result = parseExcelDate('02/15/2024');
+    expect(result.getFullYear()).toBe(2024);
+    expect(result.getMonth()).toBe(1); // February is month 1
+    expect(result.getDate()).toBe(15);
   });
 });


### PR DESCRIPTION
## Summary
- parse `mm/dd/yyyy` style dates from Excel uploads
- use new helper when reading delivery check spreadsheets
- export helper for testing
- test `parseExcelDate` for correct parsing

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_684fd9b62b0c8331a89012d11daa564b

## Summary by Sourcery

Introduce a parseExcelDate helper to support Excel date formats and integrate it into the delivery check import with accompanying tests

New Features:
- Support parsing Excel dates in both serialized number and mm/dd/yyyy string formats via a new parseExcelDate helper

Enhancements:
- Use parseExcelDate to import dates in the delivery check spreadsheet

Tests:
- Add unit test to verify parseExcelDate handles mm/dd/yyyy strings correctly